### PR TITLE
Save the selected profile with the containing data

### DIFF
--- a/src/DefaultYggdrasil.php
+++ b/src/DefaultYggdrasil.php
@@ -195,12 +195,17 @@ class DefaultYggdrasil implements Yggdrasil {
         $this->accessToken = $response['accessToken'];
         $this->clientToken = $response['clientToken'];
 
-        $selectedResponse = $response['selectedProfile'];
-        $uuid = $selectedResponse['id'];
-        $playerName = $selectedResponse['name'];
-        //only appears if true
-        $legacy = isset($selectedResponse['legacy']);
-        $this->selectedProfile = new Profile($uuid, $playerName, $legacy);
+        if (isset($response['selectedProfile'])) {
+            $selectedResponse = $response['selectedProfile'];
+
+            $uuid = $selectedResponse['id'];
+            $playerName = $selectedResponse['name'];
+            //only appears if true
+            $legacy = isset($selectedResponse['legacy']);
+            $this->selectedProfile = new Profile($uuid, $playerName, $legacy);
+        } else {
+            $this->selectedProfile = null;
+        }
     }
 
     function refresh()
@@ -218,12 +223,17 @@ class DefaultYggdrasil implements Yggdrasil {
         $this->accessToken = $response['accessToken'];
         $this->clientToken = $response['clientToken'];
 
-        $selectedResponse = $response['selectedProfile'];
-        $uuid = $selectedResponse['id'];
-        $playerName = $selectedResponse['name'];
-        //only appears if true
-        $legacy = isset($selectedResponse['legacy']);
-        $this->selectedProfile = new Profile($uuid, $playerName, $legacy);
+        if (isset($response['selectedProfile'])) {
+            $selectedResponse = $response['selectedProfile'];
+
+            $uuid = $selectedResponse['id'];
+            $playerName = $selectedResponse['name'];
+            //only appears if true
+            $legacy = isset($selectedResponse['legacy']);
+            $this->selectedProfile = new Profile($uuid, $playerName, $legacy);
+        } else {
+            $this->selectedProfile = null;
+        }
     }
 
     function validate()

--- a/src/DefaultYggdrasil.php
+++ b/src/DefaultYggdrasil.php
@@ -27,6 +27,10 @@ class DefaultYggdrasil implements Yggdrasil {
      */
     public function __construct($username = null, $clientToken = null, $accessToken = null)
     {
+        $this->username = $username;
+        $this->clientToken = $clientToken;
+        $this->accessToken = $accessToken;
+
         $this->httpClient = new Client();
     }
 

--- a/src/DefaultYggdrasil.php
+++ b/src/DefaultYggdrasil.php
@@ -14,9 +14,7 @@ class DefaultYggdrasil implements Yggdrasil {
     //these properties will be filled after a sucessfull response
     private $clientToken;
     private $accessToken;
-    private $uuid;
-    private $playerName;
-    private $legacy;
+    private $selectedProfile;
 
     /**
      * Create a new Yggdrasil for querying mojang servers
@@ -162,24 +160,14 @@ class DefaultYggdrasil implements Yggdrasil {
         return $this;
     }
 
-    function getUuid()
-    {
-        return $this->uuid;
-    }
-
-    function getPlayerName()
-    {
-        return $this->playerName;
-    }
-
-    function getLegacy()
-    {
-        return $this->legacy;
-    }
-
     function getUsername()
     {
         return $this->username;
+    }
+
+    public function getSelectedProfile()
+    {
+        return $this->selectedProfile;
     }
 
     function authenticate($password, $agent = 'Minecraft')
@@ -207,11 +195,12 @@ class DefaultYggdrasil implements Yggdrasil {
         $this->accessToken = $response['accessToken'];
         $this->clientToken = $response['clientToken'];
 
-        $profile = $response['selectedProfile'];
-        $this->uuid = $profile['id'];
-        $this->playerName = $profile['name'];
+        $selectedResponse = $response['selectedProfile'];
+        $uuid = $selectedResponse['id'];
+        $playerName = $selectedResponse['name'];
         //only appears if true
-        $this->legacy = isset($profile['legacy']);
+        $legacy = isset($selectedResponse['legacy']);
+        $this->selectedProfile = new Profile($uuid, $playerName, $legacy);
     }
 
     function refresh()
@@ -229,11 +218,12 @@ class DefaultYggdrasil implements Yggdrasil {
         $this->accessToken = $response['accessToken'];
         $this->clientToken = $response['clientToken'];
 
-        $profile = $response['selectedProfile'];
-        $this->uuid = $profile['id'];
-        $this->playerName = $profile['name'];
+        $selectedResponse = $response['selectedProfile'];
+        $uuid = $selectedResponse['id'];
+        $playerName = $selectedResponse['name'];
         //only appears if true
-        $this->legacy = isset($profile['legacy']);
+        $legacy = isset($selectedResponse['legacy']);
+        $this->selectedProfile = new Profile($uuid, $playerName, $legacy);
     }
 
     function validate()

--- a/src/DefaultYggdrasil.php
+++ b/src/DefaultYggdrasil.php
@@ -1,7 +1,6 @@
 <?php
 namespace PublicUHC\PhpYggdrasil;
 
-
 use GuzzleHttp\Client;
 
 class DefaultYggdrasil implements Yggdrasil {
@@ -10,9 +9,14 @@ class DefaultYggdrasil implements Yggdrasil {
     const SESSION_SERVER = 'https://sessionserver.mojang.com/session/minecraft';
 
     private $username;
+    private $httpClient;
+
+    //these properties will be filled after a sucessfull response
     private $clientToken;
     private $accessToken;
-    private $httpClient;
+    private $uuid;
+    private $playerName;
+    private $legacy;
 
     /**
      * Create a new Yggdrasil for querying mojang servers
@@ -154,6 +158,21 @@ class DefaultYggdrasil implements Yggdrasil {
         return $this;
     }
 
+    function getUuid()
+    {
+        return $this->uuid;
+    }
+
+    function getPlayerName()
+    {
+        return $this->playerName;
+    }
+
+    function getLegacy()
+    {
+        return $this->legacy;
+    }
+
     function getUsername()
     {
         return $this->username;
@@ -183,6 +202,12 @@ class DefaultYggdrasil implements Yggdrasil {
 
         $this->accessToken = $response['accessToken'];
         $this->clientToken = $response['clientToken'];
+
+        $profile = $response['selectedProfile'];
+        $this->uuid = $profile['id'];
+        $this->playerName = $profile['name'];
+        //only appears if true
+        $this->legacy = isset($profile['legacy']);
     }
 
     function refresh()
@@ -199,6 +224,12 @@ class DefaultYggdrasil implements Yggdrasil {
 
         $this->accessToken = $response['accessToken'];
         $this->clientToken = $response['clientToken'];
+
+        $profile = $response['selectedProfile'];
+        $this->uuid = $profile['id'];
+        $this->playerName = $profile['name'];
+        //only appears if true
+        $this->legacy = isset($profile['legacy']);
     }
 
     function validate()

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace PublicUHC\PhpYggdrasil;
+
+class Profile
+{
+
+    private $profileid;
+    private $name;
+    private $legacy;
+
+    public function __construct($profileid, $name, $legacy)
+    {
+        if (!is_string($profileid) || !is_string($name) || !is_bool($legacy))
+            throw new \Exception("Invalid arguments");
+
+        $this->profileid = $profileid;
+        $this->name = $name;
+        $this->legacy = $legacy;
+    }
+
+    /**
+     * @return string uuid of the profile without dashes
+     */
+    public function getProfileId()
+    {
+        return $this->profileid;
+    }
+
+    /**
+     * @return string most recent player name
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return bool this is true if the account isn't migrated to mojang
+     */
+    public function isLegacy()
+    {
+        return $this->legacy;
+    }
+}

--- a/src/Yggdrasil.php
+++ b/src/Yggdrasil.php
@@ -31,6 +31,13 @@ interface Yggdrasil {
     function getUsername();
 
     /**
+     * If the authentication was succesful and the user has ONE minecraft license, this contains the minecraft account.
+     *
+     * @return null|Profile the available minecraft
+     */
+    function getSelectedProfile();
+
+    /**
      * Gets an access token from the server, can be fetched with getAccessToken.
      *
      * <p>If clientToken is set it will be passed along with the authenticate function</p>
@@ -109,4 +116,4 @@ interface Yggdrasil {
      * @return HasJoinedResponse
      */
     function hasJoined($username, $loginHash);
-} 
+}


### PR DESCRIPTION
On successful authentication we receive the uuid, the most recent player name and if the minecraft account is migrated. It would be helpful to extract this data and return it to the user of this library too.

Based on http://wiki.vg/Authentication

Moreover I fixed the constructor, because it didn't set the values from the parameters.

Thank you for this awesome library. I searched a lot through Github, but this is only library which allows me all the stuff I want to. 
- Easy authentication
- Setting the client and accesstoken
- Have an additional refresh method
- An invalidate method

=> All the stuff I need to interact with yggdrasil. Thanks a lot
